### PR TITLE
Apply AutoConfiguredEmrJobTask to several RSM DAGs

### DIFF
--- a/src/dags/audauto/perf-automation-rsm-population-data-etl.py
+++ b/src/dags/audauto/perf-automation-rsm-population-data-etl.py
@@ -5,7 +5,7 @@ from ttd.aws.emr.aws_emr_versions import AwsEmrVersions
 from ttd.datasets.date_generated_dataset import DateGeneratedDataset
 from ttd.ec2.emr_instance_types.memory_optimized.r5 import R5
 from ttd.eldorado.aws.emr_cluster_task import EmrClusterTask
-from ttd.eldorado.aws.emr_job_task import EmrJobTask
+from ttd.confetti.auto_configured_emr_job_task import AutoConfiguredEmrJobTask
 from ttd.eldorado.base import TtdDag
 from ttd.eldorado.fleet_instance_types import EmrFleetInstanceTypes
 from ttd.operators.dataset_check_sensor import DatasetCheckSensor
@@ -143,20 +143,29 @@ audience_population_data_etl_cluster_task = EmrClusterTask(
 ###############################################################################
 # steps
 ###############################################################################
-audience_rsm_population_data_generation_step = EmrJobTask(
+audience_rsm_population_data_generation_step = AutoConfiguredEmrJobTask(
+    group_name="audience",
+    job_name="PopulationInputDataGeneratorJob",
     name="populationDataGenerator",
     class_name="com.thetradedesk.audience.jobs.PopulationInputDataGeneratorJob",
-    additional_args_option_pairs_list=copy.deepcopy(spark_options_list) + [
-        ("packages", "com.linkedin.sparktfrecord:spark-tfrecord_2.12:0.3.4"),
-    ],
-    eldorado_config_option_pairs_list=[('date', run_date), ('syntheticIdLength', '2000'), ('audienceResultCoalesce', 32768),
-                                       ('ttdReadEnv', policy_table_read_env),
-                                       ('AudienceModelPolicyReadableDatasetReadEnv', policy_table_read_env),
-                                       ('TDIDDensityScoreReadableDatasetReadEnv', feature_store_read_env),
-                                       ('SeedDensityScoreReadableDatasetReadEnv', feature_store_read_env),
-                                       ('AggregatedSeedReadableDatasetReadEnv', policy_table_read_env), ('ttdWriteEnv', override_env)],
-    executable_path=AUDIENCE_JAR,
-    timeout_timedelta=timedelta(hours=4)
+    emr_job_kwargs=dict(
+        additional_args_option_pairs_list=copy.deepcopy(spark_options_list) + [
+            ("packages", "com.linkedin.sparktfrecord:spark-tfrecord_2.12:0.3.4"),
+        ],
+        eldorado_config_option_pairs_list=[
+            ('date', run_date),
+            ('syntheticIdLength', '2000'),
+            ('audienceResultCoalesce', 32768),
+            ('ttdReadEnv', policy_table_read_env),
+            ('AudienceModelPolicyReadableDatasetReadEnv', policy_table_read_env),
+            ('TDIDDensityScoreReadableDatasetReadEnv', feature_store_read_env),
+            ('SeedDensityScoreReadableDatasetReadEnv', feature_store_read_env),
+            ('AggregatedSeedReadableDatasetReadEnv', policy_table_read_env),
+            ('ttdWriteEnv', override_env),
+        ],
+        executable_path=AUDIENCE_JAR,
+        timeout_timedelta=timedelta(hours=4),
+    ),
 )
 
 write_population_success_file_task = OpTask(


### PR DESCRIPTION
## Summary
- switch AudienceCalibrationAndMergeJob to AutoConfiguredEmrJobTask
- switch Imp2BrModelInferenceDataGenerator, TdidEmbeddingDotProductGeneratorOOS and TdidSeedScoreScale to AutoConfiguredEmrJobTask
- switch PopulationInputDataGeneratorJob to AutoConfiguredEmrJobTask
- switch AudiencePolicyTableGeneratorJob to AutoConfiguredEmrJobTask
- switch RelevanceModelInputGeneratorJob to AutoConfiguredEmrJobTask

## Testing
- `pytest -q` *(fails: 49 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_686f661e78f88326bf4112782106cd22