### PR TITLE
Update confetti factory config and skip logic

### DIFF
--- a/src/ttd/confetti/confetti_task_factory.py
+++ b/src/ttd/confetti/confetti_task_factory.py
@@ -153,15 +153,16 @@ def _prepare_runtime_config(
                 return (runtime_base, True, jar_path) if return_jar_path else (runtime_base, True)
             time.sleep(300)
 
-    # render all yaml templates in the same directory
+    # upload the rendered behavioral config
+    aws.load_string(rendered, key=cfg_key, bucket_name=c_bucket, replace=True)
+
+    # render and upload other yaml templates in the same directory
     d_bucket, d_prefix = aws._parse_bucket_and_key(tpl_dir, None)
     for key in aws.list_keys(prefix=d_prefix, bucket_name=d_bucket) or []:
-        if not key.endswith((".yml", ".yaml")):
+        if key.endswith("behavioral_config.yml") or not key.endswith((".yml", ".yaml")):
             continue
         tpl = aws.read_key(key, bucket_name=d_bucket)
         content = _render_template(tpl, {"date": run_date})
-        if key.endswith("behavioral_config.yml"):
-            content = rendered
         dest_key = runtime_base + key.split("/")[-1]
         dest_bucket, _ = aws._parse_bucket_and_key(dest_key, None)
         aws.load_string(content, key=dest_key, bucket_name=dest_bucket, replace=True)

--- a/tests/ttd/confetti/test_task_factory.py
+++ b/tests/ttd/confetti/test_task_factory.py
@@ -2,6 +2,7 @@ import sys
 import types
 import unittest
 from unittest.mock import MagicMock, patch
+from datetime import timedelta
 import yaml
 
 # provide minimal airflow stubs so imports succeed
@@ -219,6 +220,7 @@ from ttd.confetti.confetti_task_factory import (  # noqa: E402
     _render_template,
     _sha256_b64,
     _inject_audience_jar_path,
+    _prepare_runtime_config,
     make_confetti_tasks,
 )
 
@@ -257,6 +259,7 @@ class FactoryTest(unittest.TestCase):
         mock_instance.read_key.return_value = "hi {date}"
         mock_instance._parse_bucket_and_key.side_effect = lambda k, b: ("b", k)
         mock_instance.check_for_key.return_value = False
+        mock_instance.list_keys.return_value = []
         mock_inject.return_value = "audienceJarPath: bar"
 
         prep, gate = make_confetti_tasks(group_name="g", job_name="j", run_date="2020-01-01")
@@ -268,6 +271,30 @@ class FactoryTest(unittest.TestCase):
         ctx["ti"].xcom_push.assert_any_call(key="audienceJarPath", value=unittest.mock.ANY)
         should_run = gate.first_airflow_op().python_callable(ti=ctx["ti"])
         self.assertTrue(should_run)
+
+    @patch("ttd.confetti.confetti_task_factory.AwsCloudStorage")
+    @patch("ttd.confetti.confetti_task_factory.TtdEnvFactory.get_from_system")
+    @patch("ttd.confetti.confetti_task_factory._inject_audience_jar_path")
+    def test_prepare_renders_output_config(self, mock_inject, mock_get_env, mock_storage):
+        mock_get_env.return_value = type("E", (), {"execution_env": "prod"})()
+        instance = mock_storage.return_value
+        instance._parse_bucket_and_key.side_effect = lambda k, b: ("b", k)
+        instance.check_for_key.return_value = False
+        instance.list_keys.return_value = [
+            "p/behavioral_config.yml",
+            "p/output_config.yml",
+        ]
+
+        def _read(key, bucket_name=None):
+            return "audienceJarBranch: master\naudienceJarVersion: 1" if key.endswith("behavioral_config.yml") else "hi {date}"
+
+        instance.read_key.side_effect = _read
+        mock_inject.return_value = "audienceJarPath: bar"
+
+        _prepare_runtime_config("g", "j", "2020-01-01", "", timedelta(seconds=0))
+
+        keys = [c.kwargs.get("key") for c in instance.load_string.call_args_list]
+        self.assertTrue(any(str(k).endswith("output_config.yml") for k in keys))
 
 
 class AudienceJarPathTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- auto-render all yaml configs for Confetti jobs including output_config.yml
- check for `_SUCCESS` instead of result.yml
- upload `_START_<experiment>` marker when launching a job
- adjust tests for new S3 logic
- add unit test for output_config rendering

## Testing
- `pytest tests/ttd/confetti/test_task_factory.py::FactoryTest::test_make_tasks_pushes_xcom -q`
- `pytest tests/ttd/confetti/test_task_factory.py::FactoryTest::test_prepare_renders_output_config -q`
- `pytest tests/ttd/confetti/test_task_factory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6875e6669f8483269e8de94a406f2522