### PR TITLE
Update confetti factory config and skip logic

### DIFF
--- a/src/ttd/confetti/confetti_task_factory.py
+++ b/src/ttd/confetti/confetti_task_factory.py
@@ -108,10 +108,23 @@ def _prepare_runtime_config(
     timeout: timedelta,
     return_jar_path: bool = False,
 ) -> tuple[str, bool] | tuple[str, bool, str]:
+    """Render runtime configs and check for previous results.
+
+    The behavioral config template determines the hash used for the runtime
+    path. All YAML templates in the same directory, including ``output_config.yml``,
+    are rendered with the run date and uploaded under that path. If a ``_SUCCESS``
+    marker already exists, the job is skipped. If a ``_START_<experiment>``
+    file exists but ``_SUCCESS`` does not, the call waits for completion up to
+    ``timeout``. When new configs are uploaded a ``_START_<experiment>`` file
+    is created to mark the run.
+    """
     env = _resolve_env(TtdEnvFactory.get_from_system().execution_env, experiment)
     exp_dir = f"{experiment}/" if experiment else ""
-    tpl_key = (f"s3://{_CONFIG_BUCKET}/configdata/confetti/configs/"
-               f"{env}/{exp_dir}{group}/{job}/behavioral_config.yml")
+    tpl_dir = (
+        f"s3://{_CONFIG_BUCKET}/configdata/confetti/configs/"
+        f"{env}/{exp_dir}{group}/{job}/"
+    )
+    tpl_key = tpl_dir + "behavioral_config.yml"
 
     aws = AwsCloudStorage()
     template = aws.read_key(tpl_key)
@@ -120,27 +133,47 @@ def _prepare_runtime_config(
     jar_path = yaml.safe_load(rendered)["audienceJarPath"]
     hash_ = _sha256_b64(rendered)
 
-    runtime_base = (f"s3://{_CONFIG_BUCKET}/configdata/confetti/runtime-configs/"
-                    f"{env}/{group}/{job}/{hash_}/")
+    runtime_base = (
+        f"s3://{_CONFIG_BUCKET}/configdata/confetti/runtime-configs/"
+        f"{env}/{group}/{job}/{hash_}/"
+    )
     cfg_key = runtime_base + "behavioral_config.yml"
-    res_key = runtime_base + "result.yml"
+    success_key = runtime_base + "_SUCCESS"
+    start_key = runtime_base + (f"_START_{experiment}" if experiment else "_START")
 
-    c_bucket, c_path = aws._parse_bucket_and_key(cfg_key, None)
-    r_bucket, r_path = aws._parse_bucket_and_key(res_key, None)
+    c_bucket, _ = aws._parse_bucket_and_key(cfg_key, None)
+    s_bucket, s_path = aws._parse_bucket_and_key(success_key, None)
+    st_bucket, st_path = aws._parse_bucket_and_key(start_key, None)
 
     # fast path
-    if aws.check_for_key(r_path, r_bucket):
+    if aws.check_for_key(s_path, s_bucket):
         return (runtime_base, True, jar_path) if return_jar_path else (runtime_base, True)
 
-    # wait if config exists but result not yet ready
-    if aws.check_for_key(c_path, c_bucket):
+    # wait if another run has started the job but not finished
+    if aws.check_for_key(st_path, st_bucket):
         start = time.time()
         while time.time() - start < timeout.total_seconds():
-            if aws.check_for_key(r_path, r_bucket):
+            if aws.check_for_key(s_path, s_bucket):
                 return (runtime_base, True, jar_path) if return_jar_path else (runtime_base, True)
             time.sleep(300)
 
+    # upload the rendered behavioral config
     aws.load_string(rendered, key=cfg_key, bucket_name=c_bucket, replace=True)
+
+    # render and upload other yaml templates in the same directory
+    d_bucket, d_prefix = aws._parse_bucket_and_key(tpl_dir, None)
+    for key in aws.list_keys(prefix=d_prefix, bucket_name=d_bucket) or []:
+        if key.endswith("behavioral_config.yml") or not key.endswith((".yml", ".yaml")):
+            continue
+        tpl = aws.read_key(key, bucket_name=d_bucket)
+        content = _render_template(tpl, {"date": run_date})
+        dest_key = runtime_base + key.split("/")[-1]
+        dest_bucket, _ = aws._parse_bucket_and_key(dest_key, None)
+        aws.load_string(content, key=dest_key, bucket_name=dest_bucket, replace=True)
+
+    b_start, _ = aws._parse_bucket_and_key(start_key, None)
+    aws.load_string("", key=start_key, bucket_name=b_start, replace=True)
+
     return (runtime_base, False, jar_path) if return_jar_path else (runtime_base, False)
 
 


### PR DESCRIPTION
## Summary
- auto-render all yaml configs for Confetti jobs including output_config.yml
- check for `_SUCCESS` instead of result.yml
- upload `_START_<experiment>` marker when launching a job
- adjust tests for new S3 logic
- fix behavioral config upload loop
- wait based on `_START_*` instead of rendered config file

## Testing
- `pytest tests/ttd/confetti/test_task_factory.py::FactoryTest::test_make_tasks_pushes_xcom -q`
- `pytest tests/ttd/confetti/test_task_factory.py::FactoryTest::test_prepare_renders_output_config -q`
- `pytest tests/ttd/confetti/test_task_factory.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6875e6669f8483269e8de94a406f2522