### PR TITLE
Update confetti runtime skip logic

### DIFF
--- a/tests/ttd/confetti/test_task_factory.py
+++ b/tests/ttd/confetti/test_task_factory.py
@@ -295,6 +295,7 @@ class FactoryTest(unittest.TestCase):
 
         keys = [c.kwargs.get("key") for c in instance.load_string.call_args_list]
         self.assertTrue(any(str(k).endswith("output_config.yml") for k in keys))
+        self.assertTrue(any(str(k).endswith("_START") for k in keys))
 
 
 class AudienceJarPathTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- refine confetti runtime skip logic
- test `_START` file creation in `_prepare_runtime_config`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ttd')*

------
https://chatgpt.com/codex/tasks/task_e_68760c7706b083268ccf32966a5dfd51