### PR TITLE
Update RSM dags to use confetti_task_factory

### DIFF
--- a/src/dags/audauto/perf-automation-rsm-population-data-etl.py
+++ b/src/dags/audauto/perf-automation-rsm-population-data-etl.py
@@ -5,7 +5,9 @@ from ttd.aws.emr.aws_emr_versions import AwsEmrVersions
 from ttd.datasets.date_generated_dataset import DateGeneratedDataset
 from ttd.ec2.emr_instance_types.memory_optimized.r5 import R5
 from ttd.eldorado.aws.emr_cluster_task import EmrClusterTask
-from ttd.confetti.auto_configured_emr_job_task import AutoConfiguredEmrJobTask
+from ttd.confetti.confetti_task_factory import make_confetti_tasks
+from ttd.eldorado.xcom.helpers import get_xcom_pull_jinja_string
+from ttd.eldorado.aws.emr_job_task import EmrJobTask
 from ttd.eldorado.base import TtdDag
 from ttd.eldorado.fleet_instance_types import EmrFleetInstanceTypes
 from ttd.operators.dataset_check_sensor import DatasetCheckSensor
@@ -143,30 +145,43 @@ audience_population_data_etl_cluster_task = EmrClusterTask(
 ###############################################################################
 # steps
 ###############################################################################
-audience_rsm_population_data_generation_step = AutoConfiguredEmrJobTask(
+prep_population_data, gate_population_data = make_confetti_tasks(
     group_name="audience",
     job_name="PopulationInputDataGeneratorJob",
+    experiment_name=experiment,
+    run_date=run_date,
+)
+
+audience_rsm_population_data_generation_step = EmrJobTask(
     name="populationDataGenerator",
     class_name="com.thetradedesk.audience.jobs.PopulationInputDataGeneratorJob",
-    emr_job_kwargs=dict(
-        additional_args_option_pairs_list=copy.deepcopy(spark_options_list) + [
-            ("packages", "com.linkedin.sparktfrecord:spark-tfrecord_2.12:0.3.4"),
-        ],
-        eldorado_config_option_pairs_list=[
-            ('date', run_date),
-            ('syntheticIdLength', '2000'),
-            ('audienceResultCoalesce', 32768),
-            ('ttdReadEnv', policy_table_read_env),
-            ('AudienceModelPolicyReadableDatasetReadEnv', policy_table_read_env),
-            ('TDIDDensityScoreReadableDatasetReadEnv', feature_store_read_env),
-            ('SeedDensityScoreReadableDatasetReadEnv', feature_store_read_env),
-            ('AggregatedSeedReadableDatasetReadEnv', policy_table_read_env),
-            ('ttdWriteEnv', override_env),
-        ],
-        executable_path=AUDIENCE_JAR,
-        timeout_timedelta=timedelta(hours=4),
+    additional_args_option_pairs_list=copy.deepcopy(spark_options_list) + [
+        ("packages", "com.linkedin.sparktfrecord:spark-tfrecord_2.12:0.3.4"),
+    ],
+    eldorado_config_option_pairs_list=[
+        ('date', run_date),
+        ('syntheticIdLength', '2000'),
+        ('audienceResultCoalesce', 32768),
+        ('ttdReadEnv', policy_table_read_env),
+        ('AudienceModelPolicyReadableDatasetReadEnv', policy_table_read_env),
+        ('TDIDDensityScoreReadableDatasetReadEnv', feature_store_read_env),
+        ('SeedDensityScoreReadableDatasetReadEnv', feature_store_read_env),
+        ('AggregatedSeedReadableDatasetReadEnv', policy_table_read_env),
+        ('ttdWriteEnv', override_env),
+        (
+            'confettiRuntimeConfigBasePath',
+            get_xcom_pull_jinja_string(
+                task_ids=prep_population_data.task_id, key='confetti_runtime_config_base_path'
+            ),
+        ),
+    ],
+    executable_path=get_xcom_pull_jinja_string(
+        task_ids=prep_population_data.task_id, key='audienceJarPath'
     ),
+    timeout_timedelta=timedelta(hours=4),
 )
+
+prep_population_data >> gate_population_data >> audience_rsm_population_data_generation_step
 
 write_population_success_file_task = OpTask(
     op=WriteDateToS3FileOperator(
@@ -185,6 +200,6 @@ final_dag_status_step = OpTask(op=FinalDagStatusCheckOperator(dag=dag))
 audience_population_data_etl_cluster_task.add_parallel_body_task(audience_rsm_population_data_generation_step)
 
 (
-    population_data_etl_dag >> dataset_sensor >> density_dataset_sensor >> audience_population_data_etl_cluster_task >>
+    population_data_etl_dag >> dataset_sensor >> density_dataset_sensor >> prep_population_data >> gate_population_data >> audience_population_data_etl_cluster_task >>
     write_population_success_file_task >> final_dag_status_step
 )

--- a/src/dags/audauto/perf-automation-rsmv2-etl.py
+++ b/src/dags/audauto/perf-automation-rsmv2-etl.py
@@ -8,7 +8,8 @@ from ttd.datasets.date_generated_dataset import DateGeneratedDataset
 from ttd.datasets.hour_dataset import HourGeneratedDataset
 from ttd.ec2.emr_instance_types.memory_optimized.r5 import R5
 from ttd.eldorado.aws.emr_cluster_task import EmrClusterTask
-from ttd.confetti.auto_configured_emr_job_task import AutoConfiguredEmrJobTask
+from ttd.confetti.confetti_task_factory import make_confetti_tasks
+from ttd.eldorado.xcom.helpers import get_xcom_pull_jinja_string
 from ttd.eldorado.aws.emr_job_task import EmrJobTask
 from ttd.eldorado.base import TtdDag
 from ttd.eldorado.fleet_instance_types import EmrFleetInstanceTypes
@@ -212,29 +213,45 @@ def create_rsm_threshold_task(prefix):
     return rsm_thresholds_generation_step
 
 
-def create_rsm_job_task(name, eldorado_config_specific_list) -> AutoConfiguredEmrJobTask:
+def create_rsm_job_task(name, eldorado_config_specific_list):
     # common config
     eldorado_config_list = [('date', run_date), ('optInSeedType', 'Dynamic'),
                             ('AudienceModelPolicyReadableDatasetReadEnv', policy_table_read_env),
                             ('AggregatedSeedReadableDatasetReadEnv', policy_table_read_env),
                             ('FeatureStoreReadEnv', feature_store_read_env), ('posNegRatio', '50'), ("ttdWriteEnv", override_env)]
     eldorado_config_list.extend(eldorado_config_specific_list)
-    return AutoConfiguredEmrJobTask(
+    prep_task, gate_task = make_confetti_tasks(
         group_name="audience",
         job_name="RelevanceModelInputGeneratorJob",
+        experiment_name=experiment,
+        run_date=run_date,
+    )
+
+    job_task = EmrJobTask(
         name=name,
         class_name="com.thetradedesk.audience.jobs.modelinput.rsmv2.RelevanceModelInputGeneratorJob",
-        emr_job_kwargs=dict(
-            additional_args_option_pairs_list=(
-                copy.deepcopy(spark_options_list)
-                + [("jars", "s3://thetradedesk-mlplatform-us-east-1/libs/common/spark_tfrecord_2_12_0_3_4-56ef7.jar")]
-            ),
-            eldorado_config_option_pairs_list=eldorado_config_list,
-            action_on_failure="CONTINUE",
-            executable_path=AUDIENCE_JAR,
-            timeout_timedelta=timedelta(hours=8),
+        additional_args_option_pairs_list=(
+            copy.deepcopy(spark_options_list)
+            + [("jars", "s3://thetradedesk-mlplatform-us-east-1/libs/common/spark_tfrecord_2_12_0_3_4-56ef7.jar")]
         ),
+        eldorado_config_option_pairs_list=eldorado_config_list
+        + [
+            (
+                "confettiRuntimeConfigBasePath",
+                get_xcom_pull_jinja_string(
+                    task_ids=prep_task.task_id, key="confetti_runtime_config_base_path"
+                ),
+            )
+        ],
+        action_on_failure="CONTINUE",
+        executable_path=get_xcom_pull_jinja_string(
+            task_ids=prep_task.task_id, key="audienceJarPath"
+        ),
+        timeout_timedelta=timedelta(hours=8),
     )
+
+    prep_task >> gate_task >> job_task
+    return prep_task, gate_task, job_task
 
 
 featureReadPathPrefix = "profiles/source=bidsimpression/index=TDID/job=DailyTDIDDensityScoreSplitJobSub"
@@ -305,12 +322,16 @@ rsm_inc_tasks_config = [
 ]
 
 for cfg in rsm_full_tasks_config:
-    rsmv2_etl_full_cluster_task.add_parallel_body_task(create_rsm_job_task(cfg["name"], cfg["config"]))
+    prep, gate, job = create_rsm_job_task(cfg["name"], cfg["config"])
+    dataset_sensor >> prep
+    rsmv2_etl_full_cluster_task.add_parallel_body_task(job)
 
 # rsmv2_etl_full_cluster_task.add_parallel_body_task(create_rsm_threshold_task("Full"))
 
 for cfg in rsm_inc_tasks_config:
-    rsmv2_etl_inc_cluster_task.add_parallel_body_task(create_rsm_job_task(cfg["name"], cfg["config"]))
+    prep, gate, job = create_rsm_job_task(cfg["name"], cfg["config"])
+    dataset_sensor >> prep
+    rsmv2_etl_inc_cluster_task.add_parallel_body_task(job)
 
 # rsmv2_etl_inc_cluster_task.add_parallel_body_task(create_rsm_threshold_task("Incremental"))
 

--- a/src/dags/audauto/perf-automation-rsmv2-training-two-model.py
+++ b/src/dags/audauto/perf-automation-rsmv2-training-two-model.py
@@ -16,7 +16,9 @@ from ttd.docker import DockerEmrClusterTask, DockerCommandBuilder, DockerRunEmrT
 from ttd.ec2.emr_instance_types.graphics_optimized.g5 import G5
 from ttd.ec2.emr_instance_types.memory_optimized.r5 import R5
 from ttd.eldorado.aws.emr_cluster_task import EmrClusterTask
-from ttd.confetti.auto_configured_emr_job_task import AutoConfiguredEmrJobTask
+from ttd.confetti.confetti_task_factory import make_confetti_tasks
+from ttd.eldorado.xcom.helpers import get_xcom_pull_jinja_string
+from ttd.eldorado.aws.emr_job_task import EmrJobTask
 from ttd.eldorado.base import TtdDag
 from ttd.eldorado.fleet_instance_types import EmrFleetInstanceTypes
 from ttd.operators.dataset_check_sensor import DatasetCheckSensor
@@ -669,37 +671,49 @@ audience_embedding_merge_cluster_task = EmrClusterTask(
     cluster_auto_termination_idle_timeout_seconds=300
 )
 
-audience_embedding_merge_step = AutoConfiguredEmrJobTask(
+prep_embedding_merge, gate_embedding_merge = make_confetti_tasks(
     group_name="audience",
     job_name="AudienceCalibrationAndMergeJob",
-    name="testEmbeddingMergeJob",
-    class_name="com.thetradedesk.audience.jobs.AudienceCalibrationAndMergeJob",
-    emr_job_kwargs=dict(
-        additional_args_option_pairs_list=copy.deepcopy(spark_options_list) + [
-            ("packages", "com.linkedin.sparktfrecord:spark-tfrecord_2.12:0.3.4"),
-        ],
-        eldorado_config_option_pairs_list=[
-            ('date', run_date),
-            ('anchorStartDate', '2025-04-14'),
-            ('syntheticIdLength', '2000'),
-            ('ttd.env', f'{override_env}'),
-            (
-                'tmpSenEmbeddingDataS3Path',
-                f'configdata/{override_env}/audience/embedding_temp/RSMV2/{sensitive}/v=1'
-            ),
-            (
-                'tmpNonSenEmbeddingDataS3Path',
-                f'configdata/{override_env}/audience/embedding_temp/RSMV2/{non_sensitive}/v=1'
-            ),
-            ('embeddingDataS3Path', f'configdata/{override_env}/audience/embedding/RSMV2/v=1'),
-            ('inferenceDataS3Path', f'data/{override_env}/audience/RSMV2/prediction/'),
-            ('AudienceModelPolicyReadableDatasetReadEnv', 'prod'),
-        ],
-        executable_path=AUDIENCE_JAR,
-        timeout_timedelta=timedelta(hours=4),
-    ),
+    experiment_name=experiment,
+    run_date=run_date,
 )
 
+audience_embedding_merge_step = EmrJobTask(
+    name="testEmbeddingMergeJob",
+    class_name="com.thetradedesk.audience.jobs.AudienceCalibrationAndMergeJob",
+    additional_args_option_pairs_list=copy.deepcopy(spark_options_list) + [
+        ("packages", "com.linkedin.sparktfrecord:spark-tfrecord_2.12:0.3.4"),
+    ],
+    eldorado_config_option_pairs_list=[
+        ('date', run_date),
+        ('anchorStartDate', '2025-04-14'),
+        ('syntheticIdLength', '2000'),
+        ('ttd.env', f'{override_env}'),
+        (
+            'tmpSenEmbeddingDataS3Path',
+            f'configdata/{override_env}/audience/embedding_temp/RSMV2/{sensitive}/v=1'
+        ),
+        (
+            'tmpNonSenEmbeddingDataS3Path',
+            f'configdata/{override_env}/audience/embedding_temp/RSMV2/{non_sensitive}/v=1'
+        ),
+        ('embeddingDataS3Path', f'configdata/{override_env}/audience/embedding/RSMV2/v=1'),
+        ('inferenceDataS3Path', f'data/{override_env}/audience/RSMV2/prediction/'),
+        ('AudienceModelPolicyReadableDatasetReadEnv', 'prod'),
+        (
+            'confettiRuntimeConfigBasePath',
+            get_xcom_pull_jinja_string(
+                task_ids=prep_embedding_merge.task_id, key='confetti_runtime_config_base_path'
+            ),
+        ),
+    ],
+    executable_path=get_xcom_pull_jinja_string(
+        task_ids=prep_embedding_merge.task_id, key='audienceJarPath'
+    ),
+    timeout_timedelta=timedelta(hours=4),
+)
+
+prep_embedding_merge >> gate_embedding_merge >> audience_embedding_merge_step
 audience_embedding_merge_cluster_task.add_parallel_body_task(audience_embedding_merge_step)
 # audience_embedding_merge_cluster_task.add_parallel_body_task(audience_audience_embedding_merge_step)
 
@@ -739,7 +753,7 @@ rsm_training_dag >> etl_file_sensor >> rsm_training_sensitive_cluster_task
     rsm_training_non_sensitive_cluster_task, rsm_training_sensitive_cluster_task
 ] >> update_full_model_non_sensitive_current_file_task >> update_full_model_sensitive_current_file_task >> update_full_model_current_file_task >> update_br_model_sensitive_current_file_task >> update_br_model_nonsensitive_current_file_task >> model_merge_task >> update_full_model_success_file_task >> calibration_data_sensor
 
-calibration_data_sensor >> detect_previous_version >> prediction_data_sensor >> audience_embedding_merge_cluster_task
+calibration_data_sensor >> detect_previous_version >> prediction_data_sensor >> prep_embedding_merge >> gate_embedding_merge >> audience_embedding_merge_cluster_task
 
 (
     audience_embedding_merge_cluster_task >> update_policy_table_current_file_task >> update_embedding_success_file_task >>


### PR DESCRIPTION
## Summary
- replace deprecated `AutoConfiguredEmrJobTask` with `confetti_task_factory` tasks
- wire confetti prep/skip logic into RSM DAGs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ttd')*

------
https://chatgpt.com/codex/tasks/task_e_68775222e6308326b50be9bbb533517f