### PR TITLE
Fix duplicate task IDs in RSMV2 ETL

### DIFF
--- a/src/dags/audauto/perf-automation-rsmv2-etl.py
+++ b/src/dags/audauto/perf-automation-rsmv2-etl.py
@@ -225,6 +225,7 @@ def create_rsm_job_task(name, eldorado_config_specific_list):
         job_name="RelevanceModelInputGeneratorJob",
         experiment_name=experiment,
         run_date=run_date,
+        task_id_prefix=f"{name}_",
     )
 
     job_task = EmrJobTask(


### PR DESCRIPTION
## Summary
- allow custom task ID prefixes when creating Confetti tasks
- add unique prefixes to RSMV2 ETL Confetti tasks

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'ttd')*
- `./run_tools.sh` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6877715806108326ab98bd26bfc11b43