### PR TITLE
Fix duplicate TaskGroup ID in RSMV2 ETL DAG

### DIFF
--- a/src/dags/audauto/perf-automation-rsmv2-etl.py
+++ b/src/dags/audauto/perf-automation-rsmv2-etl.py
@@ -203,8 +203,6 @@ prep_confetti_full, gate_confetti_full = make_confetti_tasks(
     run_date=run_date,
     task_id_prefix="full_",
 )
-prep_confetti_full.as_taskgroup(rsmv2_etl_full_cluster_task.task_id)
-gate_confetti_full.as_taskgroup(rsmv2_etl_full_cluster_task.task_id)
 
 prep_confetti_inc, gate_confetti_inc = make_confetti_tasks(
     group_name="audience",
@@ -213,8 +211,6 @@ prep_confetti_inc, gate_confetti_inc = make_confetti_tasks(
     run_date=run_date,
     task_id_prefix="inc_",
 )
-prep_confetti_inc.as_taskgroup(rsmv2_etl_inc_cluster_task.task_id)
-gate_confetti_inc.as_taskgroup(rsmv2_etl_inc_cluster_task.task_id)
 
 dataset_sensor >> prep_confetti_full >> gate_confetti_full >> rsmv2_etl_full_cluster_task
 dataset_sensor >> prep_confetti_inc >> gate_confetti_inc >> rsmv2_etl_inc_cluster_task
@@ -252,24 +248,17 @@ def create_rsm_job_task(name, eldorado_config_specific_list, prep_task, gate_tas
         name=name,
         class_name="com.thetradedesk.audience.jobs.modelinput.rsmv2.RelevanceModelInputGeneratorJob",
         additional_args_option_pairs_list=(
-            copy.deepcopy(spark_options_list)
-            + [("jars", "s3://thetradedesk-mlplatform-us-east-1/libs/common/spark_tfrecord_2_12_0_3_4-56ef7.jar")]
+            copy.deepcopy(spark_options_list) +
+            [("jars", "s3://thetradedesk-mlplatform-us-east-1/libs/common/spark_tfrecord_2_12_0_3_4-56ef7.jar")]
         ),
-        eldorado_config_option_pairs_list=eldorado_config_list
-        + [
-            ("confettiEnv", confetti_env),
-            ("experimentName", experiment),
-            (
-                "confettiRuntimeConfigBasePath",
-                get_xcom_pull_jinja_string(
-                    task_ids=prep_task.task_id, key="confetti_runtime_config_base_path"
-                ),
-            )
-        ],
+        eldorado_config_option_pairs_list=eldorado_config_list +
+        [("confettiEnv", confetti_env), ("experimentName", experiment),
+         (
+             "confettiRuntimeConfigBasePath",
+             get_xcom_pull_jinja_string(task_ids=prep_task.task_id, key="confetti_runtime_config_base_path"),
+         )],
         action_on_failure="CONTINUE",
-        executable_path=get_xcom_pull_jinja_string(
-            task_ids=prep_task.task_id, key="audienceJarPath"
-        ),
+        executable_path=get_xcom_pull_jinja_string(task_ids=prep_task.task_id, key="audienceJarPath"),
         timeout_timedelta=timedelta(hours=8),
     )
 


### PR DESCRIPTION
## Summary
- remove duplicate `as_taskgroup` calls that were using the same group id as the cluster task
- run yapf formatting, flake8 linting, and mypy type checking

## Testing
- `yapf --in-place --recursive --parallel --style=code_tool_config/.style.yapf src/dags/audauto/perf-automation-rsmv2-etl.py`
- `flake8 --append-config=code_tool_config/.flake8 src/dags/audauto/perf-automation-rsmv2-etl.py`
- `mypy --config-file=code_tool_config/.mypy.ini src/dags/audauto/perf-automation-rsmv2-etl.py`

------
https://chatgpt.com/codex/tasks/task_e_6879cd1421b08326a9e6d5d88683142c