### PR TITLE
Fix Confetti gating for offline score DAG

### DIFF
--- a/src/ttd/confetti/__init__.py
+++ b/src/ttd/confetti/__init__.py
@@ -3,6 +3,6 @@ try:  # optional import to avoid heavy airflow dependency in simple contexts
 except Exception:  # pragma: no cover - airflow may not be installed
     AutoConfiguredEmrJobTask = None  # type: ignore
 
-from .confetti_task_factory import make_confetti_tasks
+from .confetti_task_factory import make_confetti_tasks, merge_gate_tasks
 
-__all__ = ["AutoConfiguredEmrJobTask", "make_confetti_tasks"]
+__all__ = ["AutoConfiguredEmrJobTask", "make_confetti_tasks", "merge_gate_tasks"]


### PR DESCRIPTION
## Summary
- add `merge_gate_tasks` helper for Confetti jobs
- use `merge_gate_tasks` to gate the RSMv2 offline score cluster

## Testing
- `pytest -q tests/ttd/confetti/test_task_factory.py::FactoryTest::test_make_tasks_pushes_xcom`

------
https://chatgpt.com/codex/tasks/task_e_687ba113aa148326a01051295d856ec7