### PR TITLE
Fail gate task on confetti wait timeout

### DIFF
--- a/src/ttd/confetti/confetti_task_factory.py
+++ b/src/ttd/confetti/confetti_task_factory.py
@@ -213,7 +213,9 @@ def _wait_for_start_and_success(
             success_key,
         )
         time.sleep(300)
-    return False
+    raise TimeoutError(
+        f"Timed out waiting for Confetti job success key {success_key}"
+    )
 
 
 def _wait_for_existing_run(aws: AwsCloudStorage, success_key: str, start_key: str, timeout: timedelta) -> bool:
@@ -229,7 +231,9 @@ def _upload_additional_configs(
     run_vars: dict[str, Any],
 ) -> None:
     for key in aws.list_keys(prefix=tpl_dir, bucket_name=_CONFIG_BUCKET) or []:
-        if key.endswith("behavioral_config.yml") or not key.endswith((".yml", ".yaml")):
+        if key.endswith("behavioral_config.yml") or not key.endswith(
+                (".yml", ".yaml")
+        ):
             continue
         tpl = aws.read_key(key, bucket_name=_CONFIG_BUCKET)
         content = _render_template(tpl, run_vars)


### PR DESCRIPTION
## Summary
- change `_wait_for_start_and_success` so timed out waits raise `TimeoutError`
- handle YAML upload filtering indentation
- test timeout failure behavior

## Testing
- `flake8 --append-config=code_tool_config/.flake8 src/ttd/confetti/confetti_task_factory.py tests/ttd/confetti/test_task_factory.py`
- `mypy --config-file=code_tool_config/.mypy.ini src/ttd/confetti/confetti_task_factory.py tests/ttd/confetti/test_task_factory.py`
- `pytest -q tests/ttd/confetti/test_task_factory.py`


------
https://chatgpt.com/codex/tasks/task_e_687f16013cc4832697e26f930e925f19