### PR TITLE
Handle runtime archive on confetti failure

### DIFF
--- a/src/ttd/confetti/__init__.py
+++ b/src/ttd/confetti/__init__.py
@@ -3,6 +3,6 @@ try:  # optional import to avoid heavy airflow dependency in simple contexts
 except Exception:  # pragma: no cover - airflow may not be installed
     AutoConfiguredEmrJobTask = None  # type: ignore
 
-from .confetti_task_factory import make_confetti_tasks
+from .confetti_task_factory import make_confetti_tasks, make_confetti_failure_cleanup_task
 
-__all__ = ["AutoConfiguredEmrJobTask", "make_confetti_tasks"]
+__all__ = ["AutoConfiguredEmrJobTask", "make_confetti_tasks", "make_confetti_failure_cleanup_task"]


### PR DESCRIPTION
## Summary
- archive confetti runtime configs on job failure via new helper
- revert timeout archiving behaviour
- test new cleanup OpTask

## Testing
- `PYTHONPATH=src pytest tests/ttd/confetti/test_task_factory.py::FactoryTest::test_wait_timeout_fails -q`
- `PYTHONPATH=src pytest tests/ttd/confetti/test_task_factory.py::CleanupTaskTest::test_cleanup_archives -q`


------
https://chatgpt.com/codex/tasks/task_e_6880b8a933948326a786e28f818decbe