### PR TITLE
Add success marker for Confetti cleanup task

### DIFF
--- a/src/dags/audauto/perf-automation-rsm-calibration-data-etl.py
+++ b/src/dags/audauto/perf-automation-rsm-calibration-data-etl.py
@@ -152,6 +152,7 @@ audience_rsm_calibration_data_generation_step = EmrJobTask(
 cleanup_runtime_task = make_confetti_failure_cleanup_task(
     job_name="CalibrationInputDataGeneratorJob",
     prep_task=prep_task,
+    cluster_id=audience_calibration_data_etl_cluster_task.cluster_id,
 )
 
 

--- a/src/dags/audauto/perf-automation-rsm-model-policy-table-etl.py
+++ b/src/dags/audauto/perf-automation-rsm-model-policy-table-etl.py
@@ -186,6 +186,7 @@ prep_policy_table >> gate_policy_table >> audience_rsm_policy_table_generation_s
 cleanup_runtime_task = make_confetti_failure_cleanup_task(
     job_name="RSMGraphPolicyTableGeneratorJob",
     prep_task=prep_policy_table,
+    cluster_id=audience_policy_table_etl_cluster_task.cluster_id,
 )
 
 # Final status check to ensure that all tasks have completed successfully

--- a/src/dags/audauto/perf-automation-rsm-population-data-etl.py
+++ b/src/dags/audauto/perf-automation-rsm-population-data-etl.py
@@ -195,6 +195,7 @@ prep_population_data >> gate_population_data >> audience_rsm_population_data_gen
 cleanup_runtime_task = make_confetti_failure_cleanup_task(
     job_name="PopulationInputDataGeneratorJob",
     prep_task=prep_population_data,
+    cluster_id=audience_population_data_etl_cluster_task.cluster_id,
 )
 
 write_population_success_file_task = OpTask(

--- a/src/dags/audauto/perf-automation-rsmv2-etl.py
+++ b/src/dags/audauto/perf-automation-rsmv2-etl.py
@@ -386,12 +386,14 @@ write_etl_success_file_task = OpTask(
 cleanup_runtime_full = make_confetti_failure_cleanup_task(
     job_name="RelevanceModelInputGeneratorJob",
     prep_task=prep_confetti_full,
+    cluster_id=rsmv2_etl_concurrent_full_cluster_task.cluster_id,
     task_id_prefix="full_",
 )
 
 cleanup_runtime_inc = make_confetti_failure_cleanup_task(
     job_name="RelevanceModelInputGeneratorJob",
     prep_task=prep_confetti_inc,
+    cluster_id=rsmv2_etl_concurrent_inc_cluster_task.cluster_id,
     task_id_prefix="inc_",
 )
 

--- a/src/dags/audauto/perf-automation-rsmv2-offline-score.py
+++ b/src/dags/audauto/perf-automation-rsmv2-offline-score.py
@@ -224,6 +224,7 @@ prep_imp2br, gate_imp2br = make_confetti_tasks(
 cleanup_runtime_imp2br = make_confetti_failure_cleanup_task(
     job_name="Imp2BrModelInferenceDataGenerator",
     prep_task=prep_imp2br,
+    cluster_id=emr_cluster_part1.cluster_id,
 )
 
 # step 3: generate the model input
@@ -268,6 +269,7 @@ prep_part2, gate_part2 = make_confetti_tasks(
 cleanup_runtime_part2 = make_confetti_failure_cleanup_task(
     job_name="RelevanceModelOfflineScoringPart2",
     prep_task=prep_part2,
+    cluster_id=emr_cluster_part2.cluster_id,
 )
 
 # Step 4: generate the raw bid request level embedding, by model prediction with spark

--- a/src/dags/audauto/perf-automation-rsmv2-training-two-model.py
+++ b/src/dags/audauto/perf-automation-rsmv2-training-two-model.py
@@ -733,6 +733,7 @@ audience_embedding_merge_cluster_task.add_parallel_body_task(audience_embedding_
 cleanup_runtime_task = make_confetti_failure_cleanup_task(
     job_name="AudienceCalibrationAndMergeJob",
     prep_task=prep_embedding_merge,
+    cluster_id=audience_embedding_merge_cluster_task.cluster_id,
 )
 
 delay_task = OpTask(op=PythonOperator(task_id="delay_task", python_callable=lambda: time.sleep(1800), dag=adag))


### PR DESCRIPTION
## Summary
- update `make_confetti_failure_cleanup_task` to write a `_SUCCESS` marker when upstream tasks succeed
- capture experiment name from `_START` and include EMR cluster id
- adapt DAGs to supply `cluster_id`
- update tests for new success behaviour

## Testing
- `pytest tests/ttd/confetti/test_task_factory.py::CleanupTaskTest::test_cleanup_archives_on_failure -q`
- `pytest tests/ttd/confetti/test_task_factory.py::CleanupTaskTest::test_cleanup_writes_success -q`
- `pytest -q` *(fails: 23 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_6881be01b5748326a0165648e86291e5