### PR TITLE
Fix dependency chain for offline score DAG

### DIFF
--- a/src/dags/audauto/perf-automation-rsmv2-offline-score.py
+++ b/src/dags/audauto/perf-automation-rsmv2-offline-score.py
@@ -379,7 +379,7 @@ data_quality_check = utils.create_emr_spark_job(
 
 rsm_etl_dag >> dataset_sensor >> prep_imp2br >> gate_imp2br >> emr_cluster_part1 >> model_sensor >> copy_feature_json >> clean_up_raw_embedding >> prep_part2 >> gate_part2 >> emr_cluster_part2
 emb_gen >> emb_aggregation >> emb_to_coldstorage >> emb_dot_product >> score_min_max_scale_population >> data_quality_check
-final_dag_check = FinalDagStatusCheckOperator(dag=adag)
-emr_cluster_part2.last_airflow_op() >> final_dag_check
-emr_cluster_part1.last_airflow_op() >> post_processing_imp2br >> final_dag_check
-emr_cluster_part2.last_airflow_op() >> post_processing_part2 >> final_dag_check
+final_dag_check = OpTask(op=FinalDagStatusCheckOperator(dag=adag))
+emr_cluster_part2 >> final_dag_check
+emr_cluster_part1 >> post_processing_imp2br >> final_dag_check
+emr_cluster_part2 >> post_processing_part2 >> final_dag_check


### PR DESCRIPTION
## Summary
- ensure final status check is an OpTask to work with TtdDag
- link post-processing tasks using BaseTask chaining

## Testing
- `flake8 --append-config=code_tool_config/.flake8 src/dags/audauto/perf-automation-rsmv2-offline-score.py` *(fails: f-string is missing placeholders)*
- `mypy --config-file=code_tool_config/.mypy.ini src/dags/audauto/perf-automation-rsmv2-offline-score.py`


------
https://chatgpt.com/codex/tasks/task_e_6881e08c88bc8326be8a7ad489c56df1