### PR TITLE
feat: relax confetti test env restriction

### DIFF
--- a/src/ttd/confetti/confetti_task_factory.py
+++ b/src/ttd/confetti/confetti_task_factory.py
@@ -163,13 +163,8 @@ def _collect_job_run_level_variables(
 def resolve_env(env: str, experiment: str) -> str:
     env = (env or "").lower()
     if env in ("prod", "production"):
-        if experiment:
-            return "experiment"
-        return "prod"
-    else:
-        if not experiment:
-            raise ValueError("experiment_name is required for test env")
-    return "test"
+        return "experiment" if experiment else "prod"
+    return "experiment" if experiment else "test"
 
 
 def _template_dir(env: str, experiment: str, group: str, job: str) -> str:

--- a/tests/ttd/confetti/test_task_factory.py
+++ b/tests/ttd/confetti/test_task_factory.py
@@ -238,9 +238,11 @@ class ResolveEnvTest(unittest.TestCase):
     def test_prod_with_experiment(self):
         self.assertEqual(resolve_env("prod", "exp"), "experiment")
 
-    def test_test_env_requires_experiment(self):
-        with self.assertRaises(ValueError):
-            resolve_env("test", "")
+    def test_non_prod_without_experiment(self):
+        self.assertEqual(resolve_env("test", ""), "test")
+
+    def test_non_prod_with_experiment(self):
+        self.assertEqual(resolve_env("test", "exp"), "experiment")
 
 
 class TemplateTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- allow confetti jobs to run in non-prod without experiment names
- expand resolve_env tests for non-prod environments

## Testing
- `PYTHONPATH=src pytest tests/ttd/confetti/test_task_factory.py::ResolveEnvTest -q` *(fails: ImportError: cannot import name 'BranchPythonOperator' from 'airflow.operators.python')*

------
https://chatgpt.com/codex/tasks/task_e_68946af6fe3c8326a0058227e3e19e23